### PR TITLE
Replace concat_idents! with the modern equivalent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(
-    concat_idents,
     io_error_more,
     let_chains,
+    macro_metavar_expr_concat,
     maybe_uninit_as_bytes,
     maybe_uninit_slice,
     never_type,

--- a/src/linux/tracing.rs
+++ b/src/linux/tracing.rs
@@ -134,7 +134,7 @@ macro_rules! syscall {
             let mut args6 = [0; 6];
             args6[..args.len()].copy_from_slice(&args);
             $crate::linux::tracing::SyscallArgs {
-                syscall_no: concat_idents!(SYS_, $name) as i32,
+                syscall_no: ${ concat(SYS_, $name) } as i32,
                 args: args6,
             }
         }


### PR DESCRIPTION
Unfortunately, I wasn't able to build the whole thing, because seccomp-tools is broken on NixOS. `cargo build` only fails for the 3 include macros, though.